### PR TITLE
add sentry fork metadata

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,6 @@
+minVersion: 0.34.0
+targets:
+- name: pypi
+- name: github
+- name: sentry-pypi
+  internalPypiRepo: getsentry/pypi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches: [main, release/**, test-me-*]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - run: |
+        set -x
+        pip install build
+        python -m build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.sha }}
+        path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          merge_target: ${{ github.event.inputs.merge_target }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+sentry-forked-email-reply-parser
+================================
+
+### new release
+
+make a new branch for the fork of the upstream tag:
+
+```bash
+git remote add upstream git@github.com:zapier/email-reply-parser
+git fetch upstream --tags
+git push origin --tags
+git checkout 1.2.3 -b sentry-1.2.3
+```
+
+- cherry-pick the craft / release commit(s) into your branch (from a previous `sentry-...` release or from `master`)
+- cherry-pick relevant commit(s) from previous releases
+
+releases are done through craft in the release.yml workflow -- make sure to
+target your particular branch with a `-#` release postfix (like `1.2.3-1`)
+
+___
+
 # Email Reply Parser for Python
 A port of GitHub's Email Reply Parser library, by the fine folks at [Zapier](https://zapier.com/).
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+if ! grep -E '^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$' <<< "$2"; then
+    : "expected #.#.#-# got $2"
+    exit 1
+fi
+sed -i "s/^VERSION = '.*'$/VERSION = '$2'/" email_reply_parser/version.py

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'email_reply_parser')
 import version
 
 setup(
-    name='email_reply_parser',
+    name='sentry_forked_email_reply_parser',
     version=version.VERSION,
     description='Email reply parser',
     packages=['email_reply_parser'],


### PR DESCRIPTION
roughly copied from sentry-forked-djangorestframework-stubs

forking to add python 3.13 support -- upstream appears to be dead